### PR TITLE
bugfix #14

### DIFF
--- a/bayesian_models/models.py
+++ b/bayesian_models/models.py
@@ -1189,6 +1189,8 @@ class BEST(ConvergenceChecksMixin, DataValidationMixin, IOMixin,
             warn(("Length of variables, ropes and hdis not equal. The"
                   " shortest value will be considered"))
         results=dict()
+        null_interval = Interval(0,0, lower_closed=False, 
+                                 upper_closed=False)
         for var_name, rope,hdi in zip(var_names,ropes, hdis):
             raw_summary = az.summary(self.idata, var_names=[var_name],
             filter_vars='like', hdi_prob=hdi)
@@ -1198,7 +1200,7 @@ class BEST(ConvergenceChecksMixin, DataValidationMixin, IOMixin,
                 ci=Interval(row[2],row[3])
                 if ci in rope:
                     out.append("Not Significant")
-                elif ci & rope != Interval(0,0):
+                elif ci & rope != null_interval:
                     out.append("Indeterminate")
                 else:
                     out.append("Significant")

--- a/tests/BEST_test.py
+++ b/tests/BEST_test.py
@@ -208,8 +208,6 @@ class TestBESTModel(unittest.TestCase):
         sig = results["Δσ"].loc[:,"Significance"]
         self.assertTrue( Δμ.iloc[0]-ref_val_mu <= ε)
 
-     # See issue #14
-    @unittest.expectedFailure
     def test_decition_rule(self):
         obj = BEST()(self.df, "group")
         obj.fit(tune=1000, draws=2000, chains=2,


### PR DESCRIPTION
Fixed bug #14, `Significant` results were mislabeled as `Indeterminate` `ci&rope = Interval(0,0, lower_closed=False, upper_closed=False)` while default has closed limits. Created single null Interval object

closed #14 