### PR TITLE
#56 `numpy` inputs to `BEST` raises

### DIFF
--- a/bayesian_models/data.py
+++ b/bayesian_models/data.py
@@ -10,8 +10,7 @@ from .typing import AXIS_PERMUTATION
 from dataclasses import dataclass, field
 
 # TODO: 
-# * Impute missing data. Maybe add slicing to the common data 
-# interface
+# * Impute missing data
 # * Much of this code is inefficient. Refactor
 # * Replace long if/else statements with structural pattern matching
 # * xarray constructor needs refactoring
@@ -234,6 +233,16 @@ class DataStructure(ABC):
     @abstractmethod
     def __gt__(self)->Union[bool, DataStructure]:
         raise NotImplementedError()
+    
+    @staticmethod
+    def __isna__(array):
+        '''
+            Custom `numpy.isnan` implementation, capable of handling arrays
+            of strings and objects. Exploits the fact that in `numpy` and
+            derived implementations `numpy.nan!=numpy.nan`
+        '''
+        cmp:Callable = np.vectorize(lambda elem : elem!=elem)
+        return cmp(array)
     
     def __mean__(self, obj, axis: Optional[int] = None, 
                  skipna:bool=True, keepdims: bool=True)->NamedTuple:

--- a/bayesian_models/data.py
+++ b/bayesian_models/data.py
@@ -238,9 +238,10 @@ class DataStructure(ABC):
     def __isna__(array):
         '''
             Custom `numpy.isnan` implementation, capable of handling arrays
-            of strings and objects. Exploits the fact that in `numpy` and
+            of objects. Exploits the fact that in `numpy` and
             derived implementations `numpy.nan!=numpy.nan`
         '''
+            
         cmp:Callable = np.vectorize(lambda elem : elem!=elem)
         return cmp(array)
     
@@ -526,11 +527,8 @@ class NDArrayStructure(DataStructure, UtilityMixin):
                 )
 
     def isna(self):
-        '''
-            Unsafe. Will raise on arrays with dtypes of string or
-            object
-        '''
-        return NDArrayStructure(np.isnan(self.obj),
+        return NDArrayStructure(
+            super().__isna__(self.obj),
                                 coords = self.coords,
                                 dims = self.dims)
         
@@ -1185,7 +1183,8 @@ class DataArrayStructure(DataStructure, UtilityMixin):
                                   )
     
     def isna(self):
-        return DataArrayStructure( np.isnan(self.obj.values),
+        return DataArrayStructure( 
+                                  super().__isna__(self._obj),
                                 coords = self._coords,
                                 dims = self._dims)
     

--- a/tests/data_module_test.py
+++ b/tests/data_module_test.py
@@ -152,6 +152,33 @@ class TestDataModule(unittest.TestCase):
         self.assertTrue(cond1 and cond2 and cond3 and cond4 and cond5 \
             and cond6 and cond7)
         
+    def test_60_expanded_nan(self):
+        '''
+            Test alternate `np.isnan` implementation that handles dtypes
+            string and object
+        '''
+        from bayesian_models.data import DataStructure
+        arr = np.random.rand(50,9,3)
+        oarr = arr.astype(object)
+        sarr = arr.astype(np.str_)
+        narr = arr.copy()
+        narr[0,0,0] = np.nan
+        narr[1,0,1] = np.nan
+        res = DataStructure.__isna__(arr)
+        nres = DataStructure.__isna__(narr)
+        ref_nan = np.zeros_like(arr, dtype=np.bool_)
+        ref_nan[0,0,0] = True
+        ref_nan[1,0,1] = True
+        predicates:PREDICATES = dict(
+            all_present = (res == np.zeros_like(arr, dtype=np.bool_)
+                           ).all(),
+            nan_present  = (nres == ref_nan).all()
+        )
+        self.assertTrue(all([
+            v for k,v in predicates.items()
+        ]))
+        
+        
     def test_np_isna(self):
         notnan = self.A
         nan = self.A.copy()

--- a/tests/data_module_test.py
+++ b/tests/data_module_test.py
@@ -1470,6 +1470,3 @@ class TestDataModule(unittest.TestCase):
         self.assertTrue([
             v for _,v in predicates.items()
         ])
-        
-    def test_60(self):
-        pass

--- a/tests/data_module_test.py
+++ b/tests/data_module_test.py
@@ -1470,3 +1470,6 @@ class TestDataModule(unittest.TestCase):
         self.assertTrue([
             v for _,v in predicates.items()
         ])
+        
+    def test_60(self):
+        pass


### PR DESCRIPTION
The reason this is happening is because `BEST` like all models call `CommonDataProcessor` to check for missing values. In this case however the `dtype` of the input is `object` and the underlying implementation relies on `numpy.isnan`, which wont't work with strings and objects. We can extend this by allowing `isnan` to work with objects:
```
cmp = np.vectoryize(lambda elem : elem!=elem)
cmp(arr)
```
This works because in IEEE specs `NaN != NaN` which `numpy.nan` implements