### PR TITLE
#56 `numpy` inputs to `BEST` raise

### DIFF
--- a/bayesian_models/data.py
+++ b/bayesian_models/data.py
@@ -378,7 +378,9 @@ class DataStructure(ABC):
                 elif isinstance(e, list):
                     subcollected:list[int] = []
                     for elem in e:
-                        if isinstance(elem, (int, str)):
+                        alltype = (int, str, np.str_, np.int_,
+                                   )
+                        if isinstance(elem, alltype):
                             subcollected.append(lookup(dim, elem)
                                 )
                         else:

--- a/bayesian_models/models.py
+++ b/bayesian_models/models.py
@@ -707,11 +707,11 @@ class BEST(BESTBase):
             e for e in next(data[:,self.group_var].unique())[1]
             ]
         self.num_levels=len(self.levels)
-        self.features = [
+        self.features = np.asarray([
             k for k in data.coords()[
                 list(data.coords().keys())[1]
                                      ] if k != self.group_var
-            ]
+            ])
         self._ndims=len(self.features)
         
         self._groups = {
@@ -839,8 +839,11 @@ class BEST(BESTBase):
                 The output of `transform`. Generally a `pandas.Series`
                 of empirical means, or standard deviations
         '''
-        
-        selected = data[row_indexer, column_indexer]
+        if isinstance(row_indexer, np.ndarray):
+            row_indexer = row_indexer.tolist()
+        if isinstance(column_indexer, np.ndarray):
+            column_indexer = column_indexer.tolist()
+        selected = data[row_indexer, :][:, column_indexer]
         transformed = transform(selected)
         if unwrap:
             warped_input=transformed.values()

--- a/tests/BEST_test.py
+++ b/tests/BEST_test.py
@@ -355,6 +355,22 @@ class TestBESTModel(unittest.TestCase):
         obj.predict()
         
     def test_56(self):
+        '''
+            Partially resolved. `pymc` tries to check with `np.isnan`
+            which will raise for dtype object (even if the underlying
+            elems really are float)
+        '''
         from sklearn.datasets import load_iris
         X, y = load_iris(return_X_y=True)
+        y = y.astype(float)
+        y = y[:,None]
+        arr = np.concatenate(
+            [X, y], axis=1
+        )
+        A = np.random.rand(30,9,3)
+        obj = BEST()(arr, 4)
+        obj.fit(tune=10, draws=10, chains=2)
+        obj.predict()
+        self.assertTrue(True)
+        
         

--- a/tests/BEST_test.py
+++ b/tests/BEST_test.py
@@ -354,3 +354,7 @@ class TestBESTModel(unittest.TestCase):
         obj.fit(tune=100, draws=100, chains=2)
         obj.predict()
         
+    def test_56(self):
+        from sklearn.datasets import load_iris
+        X, y = load_iris(return_X_y=True)
+        


### PR DESCRIPTION
Working on #60 of which #56 is a prerequisite, not listed sepperatly.  `numpy.isnan` extended, but other errors persist