### PR TITLE
#68 BEST option `effect_magnitude` raises

### DIFF
--- a/bayesian_models/core.py
+++ b/bayesian_models/core.py
@@ -664,8 +664,7 @@ class BESTCoreComponent(CoreModelComponent):
                 effect_magnitude = pymc.Deterministic(
                     v_name_magnitude, diff/pymc.math.sqrt(
                         (std1**2+std2**2)/2), dims='dimentions')
-                self.variables[v_name_magnitude].append(
-                    effect_magnitude)
+                self.variables[v_name_magnitude] = effect_magnitude
                 self._derived_quantities['effect_magnitude'].append(
                     v_name_magnitude
                 )

--- a/tests/BEST_test.py
+++ b/tests/BEST_test.py
@@ -374,4 +374,16 @@ class TestBESTModel(unittest.TestCase):
         self.assertTrue(True)
         
     def test_68(self):
-        pass
+        from sklearn.datasets import load_iris
+        
+        X, y = load_iris(return_X_y=True, as_frame=True)
+        names=load_iris().target_names
+        y=y.replace({i:names[i] for i in range(len(names))})
+        df = pd.concat([X,y], axis=1)
+        BEST.std_upper = 1e3
+        BEST.std_lower = 1e-3
+        obj = BEST()(df, "target")
+        obj = BEST(
+            std_difference=True, effect_magnitude=True
+            )(df, "target")
+        self.assertTrue(True)

--- a/tests/BEST_test.py
+++ b/tests/BEST_test.py
@@ -373,4 +373,5 @@ class TestBESTModel(unittest.TestCase):
         obj.predict()
         self.assertTrue(True)
         
-        
+    def test_68(self):
+        pass


### PR DESCRIPTION
Attempting to call BEST with the `effect_magnitude=True` option raises KeyError: 'Effect_Size(setosa, versicolor)'. MRE:
```
from sklearn.datasets import load_iris
from bayesian_models.models import BEST
import pandas as pd

X, y = load_iris(return_X_y=True, as_frame=True)
names=load_iris().target_names
y=y.replace({i:names[i] for i in range(len(names))})
 df = pd.concat([X,y], axis=1)
 BEST.std_upper = 1e3
BEST.std_lower = 1e-3
obj = BEST()(df, "target")
obj = BEST(std_difference=True, effect_magnitude=True)(df, "target")
# Raises:
# Traceback (most recent call last):
#  File "<stdin>", line 1, in <module>
#  File "/media/alexander-fyrogenis/Elements/Διδακτορικό/bayesian_models/bayeisan_models_release/tenv/lib/python3.10/site-packages/bayesian_models/models.py", line 1034, in __call__
    builder()
#  File "/media/alexander-fyrogenis/Elements/Διδακτορικό/bayesian_models/bayeisan_models_release/tenv/lib/python3.10/site-packages/bayesian_models/core.py", line 884, in __call__
#    return self.builder()
#  File "/media/alexander-fyrogenis/Elements/Διδακτορικό/bayesian_models/bayeisan_models_release/tenv/lib/python3.10/site-packages/bayesian_models/core.py", line 837, in __call__
    self.build()
#  File "/media/alexander-fyrogenis/Elements/Διδακτορικό/bayesian_models/bayeisan_models_release/tenv/lib/python3.10/site-packages/bayesian_models/core.py", line 795, in build
#    self.core_model()
#  File "/media/alexander-fyrogenis/Elements/Διδακτορικό/bayesian_models/bayeisan_models_release/tenv/lib/python3.10/site-packages/bayesian_models/core.py", line 667, in __call__
#    self.variables[v_name_magnitude].append(
KeyError: 'Effect_Size(setosa, versicolor)'
```

closes #68 